### PR TITLE
Keep the emoji I picked instead of overwriting all things

### DIFF
--- a/src/new-post.html
+++ b/src/new-post.html
@@ -163,6 +163,11 @@
       },
 
       _emojify: function() {
+        var selectedEmoji = {}
+        Array.prototype.each.call(this.$.preview.querySelectorAll('select'), function(e){
+          selectedEmoji[e.title] = e.value
+        })
+
         this.$.preview.innerHTML = '';
 
         var allLines = this.$.write.value.split('\n');
@@ -179,6 +184,10 @@
             var node = this._translateWord(words[i]);
             if (node) {
               node.title = words[i];
+              if (selectedEmoji[words[i]]) {
+                node.value = selectedEmoji[words[i]]
+              }
+
               Polymer.dom(this.$.preview).appendChild(node);
             }
           }

--- a/src/new-post.html
+++ b/src/new-post.html
@@ -163,10 +163,10 @@
       },
 
       _emojify: function() {
-        var selectedEmoji = {}
-        Array.prototype.each.call(this.$.preview.querySelectorAll('select'), function(e){
-          selectedEmoji[e.title] = e.value
-        })
+        var selectedEmoji = {};
+        Array.prototype.each.call(this.$.preview.querySelectorAll('select'), function (e){
+          selectedEmoji[e.title] = e.value;
+        });
 
         this.$.preview.innerHTML = '';
 
@@ -185,7 +185,7 @@
             if (node) {
               node.title = words[i];
               if (selectedEmoji[words[i]]) {
-                node.value = selectedEmoji[words[i]]
+                node.value = selectedEmoji[words[i]];
               }
 
               Polymer.dom(this.$.preview).appendChild(node);


### PR DESCRIPTION
This PR _hopes_ to change the new-post component so that the emoji select value is kept after the result has been translated again and replaced.

As mentioned IRL this saves the select values temporarily and apply them to the new translation elements. :v:

I say _hopes_ because I can't get the app to work in development, I think this is what's happening: https://github.com/googlecodelabs/feedback/issues/94. However we all know when we just write a bunch of code in one go they always work on the first try, right? right?! :100:

Anyways you can test it perhaps? :heart: @notwaldorf  #jsdc