### PR TITLE
Enable swipe-open in <app-drawer> for touchscreen users

### DIFF
--- a/src/moji-feed.html
+++ b/src/moji-feed.html
@@ -234,7 +234,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <app-drawer-layout id="drawerLayout">
       <!-- Drawer content -->
-      <app-drawer id="drawer" swipeOpen>
+      <app-drawer id="drawer" swipe-open>
         <div class="drawer-background">
           <app-toolbar class="left-toolbar">👋🆒🐱<span class="select-wrapper">
               <select id="selectLanguage" value="{{queryParams.lang}}" on-change="_selectLanguageChanged">

--- a/src/moji-feed.html
+++ b/src/moji-feed.html
@@ -234,7 +234,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <app-drawer-layout id="drawerLayout">
       <!-- Drawer content -->
-      <app-drawer id="drawer">
+      <app-drawer id="drawer" swipeOpen>
         <div class="drawer-background">
           <app-toolbar class="left-toolbar">👋🆒🐱<span class="select-wrapper">
               <select id="selectLanguage" value="{{queryParams.lang}}" on-change="_selectLanguageChanged">


### PR DESCRIPTION
If the `<app-drawer>` could be swiped closed (`persistent=false` by default), it should also be able to be `swipedOpen`ed. It also makes it easier for touchscreen users to operate.