### PR TITLE
Fix overflow when long unbreakable names are used

### DIFF
--- a/src/channel-item.html
+++ b/src/channel-item.html
@@ -6,7 +6,6 @@
       :host {
         display: block;
         box-sizing: border-box;
-        padding-left: 16px;
       }
 
       :host(.iron-selected) {
@@ -23,45 +22,56 @@
 
       a {
         box-sizing: border-box;
-        width: 100%;
-        text-decoration: none;
         color: #455A64;
+        display: block;
         font-weight: 300;
-        @apply(--layout-horizontal);
-        @apply(--layout-justified);
-        vertical-align: middle;
-        text-align: left;
+        text-decoration: none;
+        width: 100%;
       }
 
-      .channel-settings {
-        display: inline-block;
-        vertical-align: middle;
+      .channel-icon {
+        display: block;
         color: rgba(0, 0, 0, 0.4);
       }
 
-      .channel-settings:hover {
+      .channel-icon:hover {
         color: rgba(0, 0, 0, 0.9);
       }
 
-      .channel-name {
-        word-break: break-all;
-        word-wrap: break-word;
+      .channel-icon__left {
+        float: left;
+        padding: 8px; /* Put it here to deal \w paper-icon-button internal paddings */
+
       }
 
-      iron-icon {
-        vertical-align: middle;
+      .channel-icon__right {
+        float: right;
+      }
+
+      .channel-name {
+        display: block;
+        overflow: hidden;
+        padding: 8px; /* Put it here to deal \w paper-icon-button internal paddings */
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: auto;
       }
     </style>
 
     <a href="/[[channel.name]]?lang=[[language]]">
-      <span style="padding:8px 0;">
-        <iron-icon class="channel-settings" icon="icons:public" hidden$=[[!public]]></iron-icon>
-        <iron-icon class="channel-settings" icon="icons:private" hidden$=[[public]]></iron-icon>
-        <span class="channel-name">[[channel.name]]</span>
-      </span>
-      <paper-icon-button class="channel-settings" channel="[[channel]]" icon="icons:settings"
-          on-click="_showEditChannel" hidden$="[[!_shouldShowChannelSettings(channel, uid, offline)]]">
+      <iron-icon 
+        class="channel-icon channel-icon__left"
+        icon$=[[_getIconName(public)]]>
+      </iron-icon>
+      <paper-icon-button 
+        class="channel-icon channel-icon__right" 
+        channel="[[channel]]" 
+        icon="icons:settings"
+        on-click="_showEditChannel" 
+        hidden$="[[!_shouldShowChannelSettings(channel, uid, offline)]]">
       </paper-icon-button>
+
+      <span class="channel-name" title="[[channel.name]]">[[channel.name]]</span>
     </a>
 
   </template>
@@ -97,6 +107,10 @@
       _shouldShowChannelSettings: function(channel, uid, offline) {
         return !offline && (channel.owner === uid);
       },
+
+      _getIconName: function(isPublic) {
+        return 'icons:' + (isPublic ? 'public' : 'private');
+      }
     });
   </script>
 </dom-module>

--- a/src/channel-item.html
+++ b/src/channel-item.html
@@ -43,6 +43,11 @@
         color: rgba(0, 0, 0, 0.9);
       }
 
+      .channel-name {
+        word-break: break-all;
+        word-wrap: break-word;
+      }
+
       iron-icon {
         vertical-align: middle;
       }
@@ -52,7 +57,7 @@
       <span style="padding:8px 0;">
         <iron-icon class="channel-settings" icon="icons:public" hidden$=[[!public]]></iron-icon>
         <iron-icon class="channel-settings" icon="icons:private" hidden$=[[public]]></iron-icon>
-        <span>[[channel.name]]</span>
+        <span class="channel-name">[[channel.name]]</span>
       </span>
       <paper-icon-button class="channel-settings" channel="[[channel]]" icon="icons:settings"
           on-click="_showEditChannel" hidden$="[[!_shouldShowChannelSettings(channel, uid, offline)]]">

--- a/src/new-post.html
+++ b/src/new-post.html
@@ -85,6 +85,8 @@
         color: var(--app-secondary-text-color);
         font-weight: 300;
         font-size: 14px;
+        word-break: break-all;
+        word-wrap: break-word;
       }
     </style>
 

--- a/src/new-post.html
+++ b/src/new-post.html
@@ -46,13 +46,13 @@
       }
 
       paper-button {
+        color: var(--app-secondary-color);
+        display: block;
+        float: right;
+        font-size: 14px;
         margin: 0;
         padding: 0;
-        font-size: 14px;
-        color: var(--app-secondary-color);
-        @apply(--layout-flex);
-        @apply(--layout-flex-auto);
-        float: right;
+        text-align: center;
       }
 
       select {
@@ -85,9 +85,16 @@
         color: var(--app-secondary-text-color);
         font-weight: 300;
         font-size: 14px;
-        word-break: break-all;
-        word-wrap: break-word;
       }
+
+      .title-ellipsis {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: auto;
+      }
+
     </style>
 
     <div class="title">{{localize('new-post-header')}}</div>
@@ -96,8 +103,12 @@
     <div id="preview" tabindex="0"></div>
 
     <div class="bottom">
-      <span class="title">{{localize('in-channel')}}: [[channel]]</span>
       <paper-button on-click="_post">{{localize('post-button')}}</paper-button>
+      <span 
+        class="title title-ellipsis"
+        title="{{localize('in-channel')}}: [[channel]]">
+        {{localize('in-channel')}}: [[channel]]
+      </span>
     </div>
 
   </template>

--- a/src/view-posts.html
+++ b/src/view-posts.html
@@ -20,10 +20,12 @@
         position: static;
       }
 
-      h1 {
+      .channel-name {
         color: white;
         letter-spacing: 2px;
         font-weight: 500;
+        word-wrap: break-word;
+        word-break: break-all;
       }
 
       .item {
@@ -119,7 +121,7 @@
       persisted-data="{{posts}}">
     </app-indexeddb-mirror>
 
-    <h1>[[channel]]</h1>
+    <h1 class="channel-name">[[channel]]</h1>
     <iron-list items="[[posts]]" as="item" id="list" scroll-target="document">
       <template>
         <div>


### PR DESCRIPTION
## Problem

Long unbreakable channel names break the layout and make cute mojibrag 🔈 look ugly 😢 
For more details see #35 
## Solution

Allow browser to break unbreakable words by providing `word-wrap` and `word-break` styles for channel name views.
## Screenshots
### Before

![image](https://cloud.githubusercontent.com/assets/6533582/19701129/b872d90c-9b02-11e6-83df-f0ac7e9f61fc.png)
### After

![image](https://cloud.githubusercontent.com/assets/6533582/19701144/c35fcf5a-9b02-11e6-8a5c-86d496340817.png)
