### PR TITLE
update service worker config to properly cache offline dependencies

### DIFF
--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -12,7 +12,19 @@ module.exports = {
     '/index.html',
     '/manifest.json',
     '/bower_components/webcomponentsjs/webcomponents-lite.min.js',
-    '/bower_components/emojilib/emojis.json'
+    '/bower_components/emojilib/emojis.json',
+    // Precache offline support deps
+    // https://github.com/notwaldorf/mojibrag/issues/49
+    '/bower_components/app-storage/app-indexeddb-mirror/app-indexeddb-mirror-worker.js',
+    '/bower_components/app-storage/app-indexeddb-mirror/common-worker-scope.js',
+    '/bower_components/app-storage/app-indexeddb-mirror/common-worker.html',
+  ],
+  // Enable retrieval of cached common-scope-worker on browsers lacking SharedWorker
+  // The worker is fetched as "https://.../common-scope-worker.js?.../app-indexeddb-mirror.js"
+  // the arg needs to be stripped so we hit the cache
+  // https://github.com/notwaldorf/mojibrag/issues/49
+  ignoreUrlParametersMatching: [
+    /app-indexeddb-mirror/
   ],
   navigateFallback: '/index.html',
   navigateFallbackWhitelist: [/^(?!\/__)/, ' /getProjectConfig/'],


### PR DESCRIPTION
indexeddb-mirror deps should be pre-cached so they are always available offline

also need to strip indexeddb-mirror  worker args from common-worker url so we hit cache when offline

see https://github.com/notwaldorf/mojibrag/issues/49